### PR TITLE
Update auth & onboarding UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Created by Harman Batish
 MIT License.
 Built with ❤️ for India’s spiritual seekers.
 
+### Image Credits
+Hero illustrations sourced from [Unsplash](https://unsplash.com) under the Unsplash License.
+
 📬 Contact
 For feedback, support, or partnership:
 harman@dharmasaathi.com

--- a/components/Onboarding/LifestyleStep.tsx
+++ b/components/Onboarding/LifestyleStep.tsx
@@ -23,7 +23,11 @@ export default function LifestyleStep({ onNext }: { onNext: (data: FormData) => 
   } = useForm<FormData>({ resolver: zodResolver(schema) });
 
   return (
-    <form onSubmit={handleSubmit(onNext)} className="space-y-4">
+    <form onSubmit={handleSubmit(onNext)} className="space-y-6">
+      <div className="space-y-1 text-center">
+        <h3 className="text-xl font-semibold text-brand-blue">Lifestyle Choices</h3>
+        <p className="text-sm text-gray-600">Daily habits and preferences</p>
+      </div>
       <div className="space-y-2">
         <Label htmlFor="diet">Diet</Label>
         <Input id="diet" placeholder="Diet" {...register('diet')} />

--- a/components/Onboarding/MultiStepOnboarding.tsx
+++ b/components/Onboarding/MultiStepOnboarding.tsx
@@ -7,15 +7,22 @@ import LifestyleStep from './LifestyleStep';
 import PreferencesStep from './PreferencesStep';
 import PhotoUploadStep from './PhotoUploadStep';
 import ProfileProgressBar from '../ProfileProgressBar';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 
 export default function MultiStepOnboarding() {
-  const [step, setStep] = useState(0);
-  const [progress, setProgress] = useState(0);
+  const [step, setStep] = useState(0)
+  const [progress, setProgress] = useState(0)
 
   const next = () => {
-    setStep((s) => s + 1);
-    setProgress(((step + 1) / 6) * 100);
-  };
+    setStep((s) => s + 1)
+    setProgress(((step + 1) / 6) * 100)
+  }
 
   const steps = [
     <PersonalInfoStep onNext={next} key="personal" />,
@@ -24,15 +31,52 @@ export default function MultiStepOnboarding() {
     <LifestyleStep onNext={next} key="lifestyle" />,
     <PreferencesStep onNext={next} key="preferences" />,
     <PhotoUploadStep onNext={() => {}} key="photo" />,
-  ];
+  ]
+
+  const titles = [
+    'Personal Details',
+    'Professional Info',
+    'Spiritual Journey',
+    'Lifestyle',
+    'Partner Preferences',
+    'Photos',
+  ]
+
+  const copy = [
+    'Tell us a bit about yourself.',
+    'Share your work and education.',
+    'Let others know your spiritual path.',
+    'Your daily habits help us match you.',
+    'What are you looking for in a partner?',
+    'Add a smiling photo to finish.',
+  ]
 
   return (
-    <div className="max-w-md mx-auto p-4 space-y-6 bg-brand-beige rounded-xl shadow">
-      <div className="text-center">
-        <h2 className="text-lg font-semibold text-brand-blue">Step {step + 1} of 6</h2>
+    <div className="min-h-screen flex items-center justify-center bg-brand-beige p-4">
+      <div className="w-full max-w-xl space-y-6">
+        <div className="text-center space-y-2">
+          <img
+            src="https://images.unsplash.com/photo-1478476868527-002ae3f3a520?auto=format&fit=crop&w=100&q=80"
+            alt="Lotus"
+            className="mx-auto h-20 w-20 rounded-full object-cover"
+          />
+          <h1 className="text-3xl font-bold text-brand-blue">Create Your Profile</h1>
+          <p className="text-sm text-brand-blue/80">A few quick steps to connect with like-minded souls</p>
+        </div>
+        <Card>
+          <CardHeader className="space-y-2 text-center">
+            <CardTitle>
+              Step {step + 1} of 6: {titles[step]}
+            </CardTitle>
+            <CardDescription>{copy[step]}</CardDescription>
+            <ProfileProgressBar progress={progress} />
+          </CardHeader>
+          <CardContent>{steps[step]}</CardContent>
+        </Card>
+        <p className="text-center text-xs text-gray-500 italic">
+          &ldquo;Every connection is divine when the heart is open.&rdquo;
+        </p>
       </div>
-      <ProfileProgressBar progress={progress} />
-      <div>{steps[step]}</div>
     </div>
-  );
+  )
 }

--- a/components/Onboarding/PersonalInfoStep.tsx
+++ b/components/Onboarding/PersonalInfoStep.tsx
@@ -22,7 +22,11 @@ export default function PersonalInfoStep({ onNext }: { onNext: (data: FormData) 
   } = useForm<FormData>({ resolver: zodResolver(schema) });
 
   return (
-    <form onSubmit={handleSubmit(onNext)} className="space-y-4">
+    <form onSubmit={handleSubmit(onNext)} className="space-y-6">
+      <div className="space-y-1 text-center">
+        <h3 className="text-xl font-semibold text-brand-blue">Personal Details</h3>
+        <p className="text-sm text-gray-600">Tell us about yourself</p>
+      </div>
       <div className="space-y-2">
         <Label htmlFor="firstName">First Name</Label>
         <Input id="firstName" placeholder="First Name" {...register('firstName')} />

--- a/components/Onboarding/PhotoUploadStep.tsx
+++ b/components/Onboarding/PhotoUploadStep.tsx
@@ -19,7 +19,11 @@ export default function PhotoUploadStep({ onNext }: { onNext: (files: File[]) =>
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-1 text-center">
+        <h3 className="text-xl font-semibold text-brand-blue">Add Photos</h3>
+        <p className="text-sm text-gray-600">A smiling photo builds trust</p>
+      </div>
       <div className="space-y-2">
         <Label htmlFor="photos">Upload Photos</Label>
         <Input id="photos" type="file" multiple accept="image/*" onChange={handleFiles} />

--- a/components/Onboarding/PreferencesStep.tsx
+++ b/components/Onboarding/PreferencesStep.tsx
@@ -21,7 +21,11 @@ export default function PreferencesStep({ onNext }: { onNext: (data: FormData) =
   } = useForm<FormData>({ resolver: zodResolver(schema) });
 
   return (
-    <form onSubmit={handleSubmit(onNext)} className="space-y-4">
+    <form onSubmit={handleSubmit(onNext)} className="space-y-6">
+      <div className="space-y-1 text-center">
+        <h3 className="text-xl font-semibold text-brand-blue">Partner Preferences</h3>
+        <p className="text-sm text-gray-600">What are you looking for?</p>
+      </div>
       <div className="space-y-2">
         <Label htmlFor="age">Preferred Partner Age Range</Label>
         <Input id="age" placeholder="25-35" {...register('partnerAge')} />

--- a/components/Onboarding/ProfessionalInfoStep.tsx
+++ b/components/Onboarding/ProfessionalInfoStep.tsx
@@ -22,7 +22,11 @@ export default function ProfessionalInfoStep({ onNext }: { onNext: (data: FormDa
   } = useForm<FormData>({ resolver: zodResolver(schema) });
 
   return (
-    <form onSubmit={handleSubmit(onNext)} className="space-y-4">
+    <form onSubmit={handleSubmit(onNext)} className="space-y-6">
+      <div className="space-y-1 text-center">
+        <h3 className="text-xl font-semibold text-brand-blue">Professional Info</h3>
+        <p className="text-sm text-gray-600">Your career and education</p>
+      </div>
       <div className="space-y-2">
         <Label htmlFor="education">Education</Label>
         <Input id="education" placeholder="Education" {...register('education')} />

--- a/components/Onboarding/SpiritualInfoStep.tsx
+++ b/components/Onboarding/SpiritualInfoStep.tsx
@@ -23,7 +23,11 @@ export default function SpiritualInfoStep({ onNext }: { onNext: (data: FormData)
   } = useForm<FormData>({ resolver: zodResolver(schema) });
 
   return (
-    <form onSubmit={handleSubmit(onNext)} className="space-y-4">
+    <form onSubmit={handleSubmit(onNext)} className="space-y-6">
+      <div className="space-y-1 text-center">
+        <h3 className="text-xl font-semibold text-brand-blue">Spiritual Journey</h3>
+        <p className="text-sm text-gray-600">Share your practices and path</p>
+      </div>
       <div className="space-y-2">
         <Label htmlFor="org">Spiritual Org</Label>
         <Input id="org" placeholder="Spiritual Org" {...register('spiritualOrg')} />

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-xl border bg-white text-card-foreground shadow', className)}
+      {...props}
+    />
+  )
+)
+Card.displayName = 'Card'
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-2 p-4', className)} {...props} />
+  )
+)
+CardHeader.displayName = 'CardHeader'
+
+const CardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn('text-xl font-semibold', className)} {...props} />
+))
+CardTitle.displayName = 'CardTitle'
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm text-gray-600', className)} {...props} />
+))
+CardDescription.displayName = 'CardDescription'
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-4 pt-0', className)} {...props} />
+  )
+)
+CardContent.displayName = 'CardContent'
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-4 pt-0', className)} {...props} />
+  )
+)
+CardFooter.displayName = 'CardFooter'
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,16 +1,41 @@
-import LoginForm from '@/components/Auth/LoginForm';
-import { AuthProvider } from '@/components/Auth/AuthProvider';
+import LoginForm from '@/components/Auth/LoginForm'
+import { AuthProvider } from '@/components/Auth/AuthProvider'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 
 export default function LoginPage() {
   return (
     <AuthProvider>
       <div className="min-h-screen flex items-center justify-center bg-brand-beige p-4">
-        <div className="w-full max-w-md space-y-6 rounded-xl bg-white p-6 shadow">
-          <div className="text-center space-y-1">
-            <h1 className="text-2xl font-semibold text-brand-blue">Welcome Back</h1>
-            <p className="text-sm text-brand-blue/80">Log in to continue your journey</p>
+        <div className="w-full max-w-md space-y-6">
+          <div className="text-center space-y-2">
+            <img
+              src="https://images.unsplash.com/photo-1520857014576-2c4f4c972b57?auto=format&fit=crop&w=80&q=80"
+              alt="Lotus"
+              className="mx-auto h-16 w-16 rounded-full object-cover"
+            />
+            <h1 className="text-3xl font-bold text-brand-blue">Welcome Back</h1>
+            <p className="text-sm text-brand-blue/80">
+              Log in to continue your journey
+            </p>
           </div>
-          <LoginForm />
+          <Card>
+            <CardHeader className="text-center">
+              <CardTitle>Login to DharmaSaathi</CardTitle>
+              <CardDescription>Enter your details below</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <LoginForm />
+            </CardContent>
+          </Card>
+          <p className="text-center text-xs text-gray-500 italic">
+            &ldquo;Love rooted in dharma is love that lasts.&rdquo;
+          </p>
         </div>
       </div>
     </AuthProvider>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,16 +1,39 @@
-import SignUpForm from '@/components/Auth/SignUpForm';
-import { AuthProvider } from '@/components/Auth/AuthProvider';
+import SignUpForm from '@/components/Auth/SignUpForm'
+import { AuthProvider } from '@/components/Auth/AuthProvider'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 
 export default function SignUpPage() {
   return (
     <AuthProvider>
       <div className="min-h-screen flex items-center justify-center bg-brand-beige p-4">
-        <div className="w-full max-w-md space-y-6 rounded-xl bg-white p-6 shadow">
-          <div className="text-center space-y-1">
-            <h1 className="text-2xl font-semibold text-brand-blue">Create Account</h1>
-            <p className="text-sm text-brand-blue/80">Join DharmaSaathi today</p>
+        <div className="w-full max-w-md space-y-6">
+          <div className="text-center space-y-2">
+            <img
+              src="https://images.unsplash.com/photo-1509099836639-18baabf0a112?auto=format&fit=crop&w=80&q=80"
+              alt="Lotus"
+              className="mx-auto h-16 w-16 rounded-full object-cover"
+            />
+            <h1 className="text-3xl font-bold text-brand-blue">Join DharmaSaathi</h1>
+            <p className="text-sm text-brand-blue/80">Begin your journey to conscious connection</p>
           </div>
-          <SignUpForm />
+          <Card>
+            <CardHeader className="text-center">
+              <CardTitle>Create your account</CardTitle>
+              <CardDescription>It only takes a minute</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <SignUpForm />
+            </CardContent>
+          </Card>
+          <p className="text-center text-xs text-gray-500 italic">
+            &ldquo;Walk your path with a partner who shares your vision.&rdquo;
+          </p>
         </div>
       </div>
     </AuthProvider>


### PR DESCRIPTION
## Summary
- add shadcn card component
- redesign login and signup pages with hero branding and quotes
- revamp onboarding flow with card layout, progress text and supportive microcopy
- add small heading/microcopy in each onboarding step
- credit Unsplash photos in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68489b2f3f7483229f5a080dcd8385dc