### PR TITLE
ensure radix components run client side

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,3 +1,4 @@
+"use client"
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,3 +1,4 @@
+"use client"
 import * as React from 'react'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
 import { Check } from 'lucide-react'

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,3 +1,4 @@
+"use client"
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,3 +1,4 @@
+"use client"
 import * as React from 'react'
 import * as ProgressPrimitive from '@radix-ui/react-progress'
 

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,3 +1,4 @@
+"use client"
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 


### PR DESCRIPTION
## Summary
- mark Radix UI components as client
- run project lint and build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684975a2c8388322a870049e3619092c