### PR TITLE
Fix auth modal trigger on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Label } from "@/components/ui/label"
@@ -139,13 +138,17 @@ export default function DharmaSaathiLanding() {
               FAQ
             </Link>
           </nav>
-          <Dialog open={isLoginOpen} onOpenChange={setIsLoginOpen} modal={false}>
-            <DialogTrigger asChild>
-              <Button className="bg-primary-900 hover:bg-primary-800 text-white px-6 py-2 rounded-full shadow-lg">
-                Sign Up
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
+          <Button
+            onClick={() => setIsLoginOpen(true)}
+            className="bg-primary-900 hover:bg-primary-800 text-white px-6 py-2 rounded-full shadow-lg"
+          >
+            Sign Up
+          </Button>
+        </div>
+      </header>
+
+      <Dialog open={isLoginOpen} onOpenChange={setIsLoginOpen} modal={false}>
+        <DialogContent className="sm:max-w-md">
               <DialogHeader>
                 <DialogTitle className="text-center text-2xl font-bold text-primary-900">
                   {authMode === "login" ? "Welcome Back" : "Join DharmaSaathi"}
@@ -306,8 +309,6 @@ export default function DharmaSaathiLanding() {
               </div>
             </DialogContent>
           </Dialog>
-        </div>
-      </header>
 
       {/* Hero Section */}
       <section className="relative py-20 lg:py-32 overflow-hidden">


### PR DESCRIPTION
## Summary
- open sign-up modal from homepage buttons
- move auth dialog outside header and trigger via onClick handlers

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found '@/components/Auth/AuthProvider')*

------
https://chatgpt.com/codex/tasks/task_e_6849d58ca9c083229f705719182364d2