### PR TITLE
Fix signup modal and restore auth provider

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Label } from "@/components/ui/label"
@@ -139,13 +138,17 @@ export default function DharmaSaathiLanding() {
               FAQ
             </Link>
           </nav>
-          <Dialog open={isLoginOpen} onOpenChange={setIsLoginOpen} modal={false}>
-            <DialogTrigger asChild>
-              <Button className="bg-primary-900 hover:bg-primary-800 text-white px-6 py-2 rounded-full shadow-lg">
-                Sign Up
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
+          <Button
+            onClick={() => setIsLoginOpen(true)}
+            className="bg-primary-900 hover:bg-primary-800 text-white px-6 py-2 rounded-full shadow-lg"
+          >
+            Sign Up
+          </Button>
+        </div>
+      </header>
+
+      <Dialog open={isLoginOpen} onOpenChange={setIsLoginOpen} modal={false}>
+        <DialogContent className="sm:max-w-md">
               <DialogHeader>
                 <DialogTitle className="text-center text-2xl font-bold text-primary-900">
                   {authMode === "login" ? "Welcome Back" : "Join DharmaSaathi"}
@@ -306,8 +309,6 @@ export default function DharmaSaathiLanding() {
               </div>
             </DialogContent>
           </Dialog>
-        </div>
-      </header>
 
       {/* Hero Section */}
       <section className="relative py-20 lg:py-32 overflow-hidden">

--- a/components/Auth/AuthProvider.tsx
+++ b/components/Auth/AuthProvider.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+import { type Session } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabaseClient'
+
+interface AuthContextType {
+  session: Session | null
+  loading: boolean
+}
+
+const AuthContext = createContext<AuthContextType>({ session: null, loading: true })
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+      setLoading(false)
+    })
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+      setLoading(false)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  return <AuthContext.Provider value={{ session, loading }}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/components/Auth/LoginForm.tsx
+++ b/components/Auth/LoginForm.tsx
@@ -1,0 +1,60 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { supabase } from '@/lib/supabaseClient'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
+  const onSubmit = async (data: FormData) => {
+    await supabase.auth.signInWithPassword({ email: data.email, password: data.password })
+  }
+
+  const handleSocial = async (provider: 'google' | 'facebook' | 'apple') => {
+    await supabase.auth.signInWithOAuth({ provider })
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" type="email" placeholder="you@example.com" {...register('email')} />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="password">Password</Label>
+        <Input id="password" type="password" placeholder="Your password" {...register('password')} />
+        {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+      </div>
+      <Button type="submit" disabled={isSubmitting} className="w-full">
+        Login
+      </Button>
+      <div className="flex justify-center gap-4 text-sm">
+        <button type="button" onClick={() => handleSocial('google')} className="underline">
+          Google
+        </button>
+        <button type="button" onClick={() => handleSocial('facebook')} className="underline">
+          Facebook
+        </button>
+        <button type="button" onClick={() => handleSocial('apple')} className="underline">
+          Apple
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/components/Auth/SignUpForm.tsx
+++ b/components/Auth/SignUpForm.tsx
@@ -1,0 +1,60 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { supabase } from '@/lib/supabaseClient'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function SignUpForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
+  const onSubmit = async (data: FormData) => {
+    await supabase.auth.signUp({ email: data.email, password: data.password })
+  }
+
+  const handleSocial = async (provider: 'google' | 'facebook' | 'apple') => {
+    await supabase.auth.signInWithOAuth({ provider })
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" type="email" placeholder="you@example.com" {...register('email')} />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="password">Password</Label>
+        <Input id="password" type="password" placeholder="Create a password" {...register('password')} />
+        {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+      </div>
+      <Button type="submit" disabled={isSubmitting} className="w-full">
+        Sign Up
+      </Button>
+      <div className="flex justify-center gap-4 text-sm">
+        <button type="button" onClick={() => handleSocial('google')} className="underline">
+          Google
+        </button>
+        <button type="button" onClick={() => handleSocial('facebook')} className="underline">
+          Facebook
+        </button>
+        <button type="button" onClick={() => handleSocial('apple')} className="underline">
+          Apple
+        </button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- bring back AuthProvider, LoginForm, and SignUpForm
- wrap onboarding page with AuthProvider again
- use `useAuth` hook in onboarding form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849d58ca9c083229f705719182364d2