### PR TITLE
Fix onboarding login flow

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,11 +1,20 @@
-"use client"
-import { AuthProvider } from "@/components/Auth/AuthProvider";
-import OnboardingForm from "@/components/OnboardingV2/onboarding-form";
+import { redirect } from 'next/navigation'
+import { cookies } from 'next/headers'
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import OnboardingForm from '@/components/OnboardingV2/onboarding-form'
+import { AuthProvider } from '@/components/Auth/AuthProvider'
 
-export default function OnboardingPage() {
+export default async function OnboardingPage() {
+  const supabase = createServerComponentClient({ cookies })
+  const { data } = await supabase.auth.getSession()
+
+  if (!data.session) {
+    redirect('/')
+  }
+
   return (
-    <AuthProvider>
+    <AuthProvider initialSession={data.session}>
       <OnboardingForm />
     </AuthProvider>
-  );
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -153,16 +153,14 @@ export default function DharmaSaathiLanding() {
       last_name: lastName,
       phone_number: `${selectedCountryCode}${phoneNumber}`,
     })
-    if (!data.session) {
-      const { error: signInError } = await supabase.auth.signInWithPassword({
-        email: signupEmail,
-        password: signupPassword,
-      })
-      if (signInError) {
-        setSignupError(signInError.message)
-        setIsSubmitting(false)
-        return
-      }
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: signupEmail,
+      password: signupPassword,
+    })
+    if (signInError) {
+      setSignupError(signInError.message)
+      setIsSubmitting(false)
+      return
     }
     setIsSubmitting(false)
     setIsLoginOpen(false)

--- a/components/Auth/AuthProvider.tsx
+++ b/components/Auth/AuthProvider.tsx
@@ -10,23 +10,30 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType>({ session: null, loading: true })
 
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [session, setSession] = useState<Session | null>(null)
-  const [loading, setLoading] = useState(true)
+interface AuthProviderProps {
+  children: React.ReactNode
+  initialSession?: Session | null
+}
+
+export const AuthProvider = ({ children, initialSession }: AuthProviderProps) => {
+  const [session, setSession] = useState<Session | null>(initialSession ?? null)
+  const [loading, setLoading] = useState(!initialSession)
 
   useEffect(() => {
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, s) => {
+      setSession(s)
       setLoading(false)
     })
-    supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session)
-      setLoading(false)
-    })
+    if (!initialSession) {
+      supabase.auth.getSession().then(({ data }) => {
+        setSession(data.session)
+        setLoading(false)
+      })
+    }
     return () => {
       listener.subscription.unsubscribe()
     }
-  }, [])
+  }, [initialSession])
 
   return <AuthContext.Provider value={{ session, loading }}>{children}</AuthContext.Provider>
 }

--- a/components/OnboardingV2/onboarding-form.tsx
+++ b/components/OnboardingV2/onboarding-form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from "@/components/Auth/AuthProvider";
 import Spinner from "@/components/ui/spinner";
+import { useRouter } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import BasicInfoStep from "./steps/basic-info-step";
 import SpiritualPathStep from "./steps/spiritual-path-step";
@@ -18,6 +19,7 @@ import ProgressIndicator from "./progress-indicator";
 
 export default function OnboardingForm() {
   const { session, loading } = useAuth();
+  const router = useRouter();
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({});
   const [isComplete, setIsComplete] = useState(false);
@@ -59,6 +61,12 @@ export default function OnboardingForm() {
     setIsComplete(false);
   };
 
+  useEffect(() => {
+    if (!loading && !session) {
+      router.push('/');
+    }
+  }, [loading, session, router]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-screen">
@@ -67,9 +75,6 @@ export default function OnboardingForm() {
     );
   }
 
-  if (!session) {
-    return <p>Please log in to continue</p>;
-  }
 
   if (isComplete) {
     return <WelcomeScreen onStartOver={handleStartOver} />;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@supabase/auth-helpers-nextjs": "^0.9.0",
         "@supabase/supabase-js": "^2.50.0",
         "@types/node": "20.6.2",
         "@types/react": "18.2.22",
@@ -1396,6 +1397,33 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.9.0.tgz",
+      "integrity": "sha512-V+UKFngSCkzAucX3Zi5D4TRiJZUUx0RDme7W217nIkwhCTvJY7Ih2L1cgnAMihQost2YYgTzJ7DrUzz4mm8i8A==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.6.3",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.19.0"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.6.3.tgz",
+      "integrity": "sha512-xYQRLFeFkL4ZfwC7p9VKcarshj3FB2QJMgJPydvOY7J5czJe6xSG5/wM1z63RmAzGbCkKg+dzpq61oeSyWiGBQ==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.14.4"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.19.0"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.70.0",
@@ -3997,6 +4025,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5141,6 +5178,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
     "@supabase/supabase-js": "^2.50.0",
+    "@supabase/auth-helpers-nextjs": "^0.9.0",
     "@types/node": "20.6.2",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",


### PR DESCRIPTION
## Summary
- ensure onboarding route redirects if unauthenticated
- pass initial session to AuthProvider for consistent auth state
- redirect to homepage from onboarding form when session expires
- always sign user in after signup
- add auth helpers package

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ec2c5b908322ab2c7c951d0ca127