### PR TITLE
Enable auto login on sign up

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ DharmaSaathi is India’s first spiritual matrimony and conscious dating platfor
   - Report/block users, admin dashboard, KYC verification, analytics
 
 - **Safety, Trust, and Privacy First**  
-  - All profiles must verify by email/OTP  
+  - Email/OTP verification available for added security
   - KYC/ID badge, privacy settings, incognito browsing (premium)
 
 ---
@@ -129,6 +129,9 @@ NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 NEXT_PUBLIC_RAZORPAY_KEY_ID=your-razorpay-key-id
 # (Do NOT expose secret keys on frontend!)
+
+Ensure in your Supabase project settings that email confirmation is disabled so
+new users can sign in immediately.
 
 **4. Run the app locally
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -154,25 +154,17 @@ export default function DharmaSaathiLanding() {
       phone_number: `${selectedCountryCode}${phoneNumber}`,
     })
 
-    if (!data.session) {
-      const { error: signInError } = await supabase.auth.signInWithPassword({
-        email: signupEmail,
-        password: signupPassword,
-      })
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: signupEmail,
+      password: signupPassword,
+    })
 
-      if (signInError) {
-        const msg = signInError.message.toLowerCase()
-        if (msg.includes('confirm') || msg.includes('verify')) {
-          setSignupError('Please check your email to verify your account.')
-        } else {
-          setSignupError(signInError.message)
-        }
-        setIsSubmitting(false)
-        return
-      }
+    if (signInError) {
+      setSignupError(signInError.message)
+      setIsSubmitting(false)
+      return
     }
- main
-    }
+
     setIsSubmitting(false)
     setIsLoginOpen(false)
     router.push("/onboarding")


### PR DESCRIPTION
## Summary
- auto-login users after email/password sign-up
- clarify Supabase auth settings in README
- adjust README messaging around verification

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849f1a14f388322a162a02eed0b1a1b